### PR TITLE
Per RPC timeout

### DIFF
--- a/python/realtime_raw_point_by_geometry.py
+++ b/python/realtime_raw_point_by_geometry.py
@@ -1,4 +1,4 @@
-from client import create_gateway_client, retry_stream, CLIENT_TIMEOUT_SEC
+from client import create_gateway_client, retry_stream, TIMEOUT_SEC
 import compassiot.platform.v1.streaming_pb2 as streaming
 
 
@@ -10,7 +10,7 @@ def main():
         stream_env= streaming.StreamEnvironment.DEV
     )
     
-    for response in retry_stream(lambda: client.RealtimeRawPointByGeometry(request, timeout=CLIENT_TIMEOUT_SEC)):
+    for response in retry_stream(lambda: client.RealtimeRawPointByGeometry(request, timeout=TIMEOUT_SEC)):
         print(response)
 
 

--- a/python/realtime_raw_point_by_vins.py
+++ b/python/realtime_raw_point_by_vins.py
@@ -1,4 +1,4 @@
-from client import create_gateway_client, retry_stream
+from client import create_gateway_client, retry_stream, TIMEOUT_SEC
 import compassiot.platform.v1.streaming_pb2 as streaming
 
 
@@ -10,7 +10,7 @@ def main():
         stream_env= streaming.StreamEnvironment.DEV
     )
     
-    for response in retry_stream(lambda: client.RealtimeRawPointByVins(request)):
+    for response in retry_stream(lambda: client.RealtimeRawPointByVins(request, timeout=TIMEOUT_SEC)):
         print(response)
 
 

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -5,7 +5,7 @@ import { Code, ConnectError, createPromiseClient, PromiseClient, type Intercepto
 
 const HOST = "https://api.compassiot.cloud"
 const SECRET = "__INSERT_YOUR_COMPASSIOT_API_KEY__"
-const CLIENT_TIMEOUT_MS = 1000 * 60 * 4.5 //  must be lower than server timeout of 5 mins from GCP
+const TIMEOUT_MS = 1000 * 60 * 25  // used by retryStream
 
 function createAuthInterceptor(secret: string, client: PromiseClient<typeof Service>): Interceptor {
   // Need a `let` so we can replace the access token for long-lived usage
@@ -43,7 +43,6 @@ function createNodeClient(options?: Omit<NodeTransportOptions, "baseUrl" | "http
     baseUrl: HOST,
     httpVersion: "2",
     interceptors: [createAuthInterceptor(SECRET, noauthClient)],
-    defaultTimeoutMs: CLIENT_TIMEOUT_MS,
     ...options,
   })
   return createPromiseClient(Service, transport)
@@ -56,7 +55,6 @@ function createWebClient(options?: Omit<WebTransportOptions, "baseUrl">): Promis
   const transport = createWebTransport({
     baseUrl: HOST,
     interceptors: [createAuthInterceptor(SECRET, noauthClient)],
-    defaultTimeoutMs: CLIENT_TIMEOUT_MS,
     ...options,
   })
   return createPromiseClient(Service, transport)
@@ -82,4 +80,4 @@ async function* retryStream<T>(stream: () => AsyncIterable<T>): AsyncIterable<T>
   }
 }
 
-export { createNodeClient, createWebClient, retryStream }
+export { createNodeClient, createWebClient, retryStream, TIMEOUT_MS }

--- a/typescript/src/realtime_raw_point_by_geometry.ts
+++ b/typescript/src/realtime_raw_point_by_geometry.ts
@@ -1,6 +1,6 @@
 import * as streaming from "@buf/compassiot_api.bufbuild_es/compassiot/platform/v1/streaming_pb"
 
-import { createNodeClient, retryStream } from "./client"
+import { TIMEOUT_MS, createNodeClient, retryStream } from "./client"
 
 const client = createNodeClient()
 
@@ -9,6 +9,6 @@ const request = new streaming.RealtimeRawPointByGeometryRequest({
   streamEnv: streaming.StreamEnvironment.DEV
 })
 
-for await (const response of retryStream(() => client.realtimeRawPointByGeometry(request))) {
+for await (const response of retryStream(() => client.realtimeRawPointByGeometry(request, { timeoutMs: TIMEOUT_MS }))) {
   console.log(response.toJsonString({ prettySpaces: 2 }))
 }

--- a/typescript/src/realtime_raw_point_by_vins.ts
+++ b/typescript/src/realtime_raw_point_by_vins.ts
@@ -1,6 +1,6 @@
 import * as streaming from "@buf/compassiot_api.bufbuild_es/compassiot/platform/v1/streaming_pb"
 
-import { createNodeClient, retryStream } from "./client"
+import { TIMEOUT_MS, createNodeClient, retryStream } from "./client"
 
 const client = createNodeClient()
 
@@ -9,6 +9,6 @@ const request = new streaming.RealtimeRawPointByVinsRequest({
   streamEnv: streaming.StreamEnvironment.DEV
 })
 
-for await (const response of retryStream(() => client.realtimeRawPointByVins(request))) {
+for await (const response of retryStream(() => client.realtimeRawPointByVins(request, { timeoutMs: TIMEOUT_MS }))) {
   console.log(response.toJsonString({ prettySpaces: 2 }))
 }


### PR DESCRIPTION
This change aims to support gateway's write timeout in a cleaner way. Specifying timeout on RPC basis (the ones that use `retryStream` or `retry_stream`) feels better than coupling them together under transport in TS & interceptor in Python. You can DM me if you need more clarification